### PR TITLE
Allow TOTP to be disabled globally

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -50,6 +50,9 @@ mfa:
     host: "HOST"
     user_agent: "nginx-sso"
 
+  totp:
+    enabled: false
+
 providers:
   # Authentication against an Atlassian Crowd directory server
   # Supports: Users, Groups


### PR DESCRIPTION
each MFA provider should be able to be disabled globally without removing it for each user