### PR TITLE
Prefer simple authenticator over LDAP

### DIFF
--- a/core.go
+++ b/core.go
@@ -14,11 +14,11 @@ import (
 )
 
 func registerModules() {
+	registerAuthenticator(simple.New(cookieStore))
 	registerAuthenticator(crowd.New())
 	registerAuthenticator(ldap.New(cookieStore))
 	registerAuthenticator(google.New(cookieStore))
 	registerAuthenticator(oidc.New(cookieStore))
-	registerAuthenticator(simple.New(cookieStore))
 	registerAuthenticator(token.New())
 	registerAuthenticator(auth_yubikey.New(cookieStore))
 


### PR DESCRIPTION
Allows to have local accounts that always work, even if there are LDAP
problems