### PR TITLE
Fix: Config loading after CookieStore init

### DIFF
--- a/main.go
+++ b/main.go
@@ -144,9 +144,10 @@ func main() {
 		case syscall.SIGHUP:
 			if yamlSource, err = loadConfiguration(); err != nil {
 				log.WithError(err).Error("Unable to reload configuration")
-			}
-			if err = initializeModules(yamlSource); err != nil {
-				log.WithError(err).Fatal("Unable to initialize modules")
+			} else {
+				if err = initializeModules(yamlSource); err != nil {
+					log.WithError(err).Error("Unable to initialize modules")
+				}
 			}
 
 		default:


### PR DESCRIPTION
Hello,

As discussed on Mastodon here is the fix I've done.
I've divided the loadConfiguration function in two so it will first load the config and initialize the cookie store and then in loadModules it calls the initialize functions.