### PR TITLE
Support TOTP autofill in Safari

### DIFF
--- a/mfa.go
+++ b/mfa.go
@@ -11,10 +11,11 @@ import (
 )
 
 var mfaLoginField = plugins.LoginField{
-	Label:       "MFA Token",
-	Name:        plugins.MFALoginFieldName,
-	Placeholder: "(optional)",
-	Type:        "text",
+	Label:         "MFA Token",
+	Name:          plugins.MFALoginFieldName,
+	Placeholder:   "(optional)",
+	Type:          "text",
+	autocomplete:  "one-time-code",
 }
 
 var (


### PR DESCRIPTION
This commit adds the functionality for safari to autofill the MFA-code.

<img width="463" alt="Safari autofill image" src="https://user-images.githubusercontent.com/68869895/154791893-56fdbae3-28cd-4c88-83af-ac23914142c0.png">

